### PR TITLE
Use numeric uid in Dockerfile for fix runAsNonRoot

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -18,6 +18,7 @@ LABEL org.opencontainers.image.source https://github.com/kubeops/config-syncer
 
 ADD bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 
-USER nobody
+# USER nobody
+USER 65534
 
 ENTRYPOINT ["/{ARG_BIN}"]


### PR DESCRIPTION
Fixes: container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root