### PR TITLE
feat: change fixed namespace for RoleBinding

### DIFF
--- a/charts/kubed/templates/apiregistration.yaml
+++ b/charts/kubed/templates/apiregistration.yaml
@@ -29,7 +29,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubed.fullname" . }}-apiserver-extension-server-authentication-reader
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubed.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
Instead of having inside the RoleBinding the `kube-system` as fixed namespace, I want to change it for getting the value for the `{{ .Release.Namespace }}` because it's not required to have it on the `kube-system` namespace

Signed-off-by: alfredo-gil <85618455+alfredo-gil@users.noreply.github.com>